### PR TITLE
Allow GitHub requests with personal access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Alfred 5 with [PowerPack](https://www.alfredapp.com/powerpack/)
 - Set the your GitHub username to `username`.
 - You can also set a limit for pages retrieved from [GitHub's paginated API](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api), your results will include `max_pages` * 30 recent starred repos. Recommended when you have a large database. Default (-1) fetches all starred repos.
 - Set cache time-to-live in minutes in `cache_ttl`, default is 60 minutes before the old cache expires.
+- Optionally, if you'd like to take advantage of higher rate-limits, set a GitHub person access token.
 
 Please note the GitHub API currently restricts anonymous requests to a maximum of 60 calls per hour. It is advised not to run the workflow too often when you set `cache_ttl` at a very small value.
 

--- a/src/github-stars.py
+++ b/src/github-stars.py
@@ -4,6 +4,7 @@ import requests
 import time
 
 username = os.getenv('username')
+token = os.getenv('github_api_token')
 cache_path = os.getenv('alfred_workflow_cache')
 cache_response = os.path.join(cache_path, 'cache.json')
 cache_ttl = float(os.getenv('cache_ttl'))  # in minutes
@@ -28,7 +29,11 @@ else:
             break
         
         starred_url = f'https://api.github.com/users/{username}/starred?page={page}'
-        response = requests.get(starred_url, headers={'User-Agent': 'GitHub Stars Alfred workflow for: ' + username})
+        headers={'User-Agent': 'GitHub Stars Alfred workflow for: ' + username}
+        if token:
+            headers['Authorization'] = 'Bearer ' + token
+
+        response = requests.get(starred_url, headers=headers)
         http_status = response.status_code
         page_data = response.json()
 

--- a/src/info.plist
+++ b/src/info.plist
@@ -185,6 +185,8 @@ Python3 and `requests` library
 
 - `max_pages` sets the limit for pages retrieved from [GitHub's paginated API](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api), your results will include `max_pages` * 30 recent starred repos. Default (-1) fetches all starred repos.
 
+- `github_api_token` is your GitHub personal access token to authenticate with GitHub when fetching data (optional). Authenticated requests have a much higher rate-limiting threshold. Recommended if you consistently get rate-limit errors.
+
 ## Usage
 
 - type `ghs` to list and search
@@ -286,6 +288,27 @@ Python3 and `requests` library
 			<string>textfield</string>
 			<key>variable</key>
 			<string>cache_ttl</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string>Please enter your personel access token, leaving empty makes anonymous requests to GitHub</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>(Optional) Access token to make authenticated calls to the GitHub API. Calls made to GitHub with tokens have higher thresholds for rate-limiting.</string>
+			<key>label</key>
+			<string>GitHub API Personal Access Token</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>github_api_token</string>
 		</dict>
 	</array>
 	<key>variablesdontexport</key>


### PR DESCRIPTION
This PR adds a configuration option to provide a GitHub Personal Access token and would use it to call GitHub API if one provided. 